### PR TITLE
Use python3 when calling make_wavs.py from CMake

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,7 +61,7 @@ if(PIMP_BUILD_TESTS)
     enable_testing()
 
     # run python script to create test data
-    execute_process(COMMAND python tests/make_wavs.py
+    execute_process(COMMAND python3 tests/make_wavs.py
         WORKING_DIRECTORY ${CMAKE_CURRENT_LIST_DIR})
 
     add_subdirectory(external/Unity)


### PR DESCRIPTION
Fix for 1f7b03965142f10fb42bc81c893d2dcc718bdaf2 when both `python` and `python3` are installed. Also, closes #1 for me.